### PR TITLE
feat: Add Baby Log webpage with voice-to-text logging

### DIFF
--- a/babylog.css
+++ b/babylog.css
@@ -1,0 +1,39 @@
+body {
+    font-family: sans-serif;
+    margin: 20px;
+}
+
+h1 {
+    text-align: center;
+}
+
+button {
+    padding: 10px 20px;
+    font-size: 16px;
+    cursor: pointer;
+    margin: 10px;
+}
+
+#confirmation-area, #records-area {
+    margin-top: 20px;
+    padding: 20px;
+    border: 1px solid #ccc;
+    border-radius: 5px;
+}
+
+#filters {
+    margin-bottom: 20px;
+}
+
+#records-container {
+    margin-top: 10px;
+}
+
+.record {
+    padding: 10px;
+    border-bottom: 1px solid #eee;
+}
+
+.record:last-child {
+    border-bottom: none;
+}

--- a/babylog.html
+++ b/babylog.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Baby Log</title>
+    <link rel="stylesheet" href="babylog.css">
+</head>
+<body>
+    <h1>Baby Log</h1>
+
+    <button id="log-button">Log</button>
+    <button id="show-records-button">Show Records</button>
+
+    <div id="confirmation-area" style="display: none;">
+        <p id="transcribed-text"></p>
+        <button id="confirm-button">Confirm</button>
+        <button id="try-again-button">Try Again</button>
+    </div>
+
+    <div id="records-area" style="display: none;">
+        <h2>Records</h2>
+        <div id="filters">
+            <label for="start-date">From:</label>
+            <input type="datetime-local" id="start-date">
+            <label for="end-date">To:</label>
+            <input type="datetime-local" id="end-date">
+            <button id="filter-button">Filter</button>
+        </div>
+        <div id="records-container"></div>
+    </div>
+
+    <script src="babylog.js"></script>
+</body>
+</html>

--- a/babylog.js
+++ b/babylog.js
@@ -1,0 +1,150 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const logButton = document.getElementById('log-button');
+    const showRecordsButton = document.getElementById('show-records-button');
+    const confirmationArea = document.getElementById('confirmation-area');
+    const transcribedText = document.getElementById('transcribed-text');
+    const confirmButton = document.getElementById('confirm-button');
+    const tryAgainButton = document.getElementById('try-again-button');
+    const recordsArea = document.getElementById('records-area');
+    const recordsContainer = document.getElementById('records-container');
+    const filterButton = document.getElementById('filter-button');
+    const startDateInput = document.getElementById('start-date');
+    const endDateInput = document.getElementById('end-date');
+
+    let recognition;
+    let final_transcript = '';
+
+    const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
+    if (SpeechRecognition) {
+        recognition = new SpeechRecognition();
+        recognition.continuous = false;
+        recognition.interimResults = true;
+
+        recognition.onstart = () => {
+            logButton.textContent = 'Listening...';
+            logButton.disabled = true;
+            confirmationArea.style.display = 'none';
+        };
+
+        recognition.onresult = (event) => {
+            let interim_transcript = '';
+            final_transcript = '';
+            for (let i = event.resultIndex; i < event.results.length; ++i) {
+                if (event.results[i].isFinal) {
+                    final_transcript += event.results[i][0].transcript;
+                } else {
+                    interim_transcript += event.results[i][0].transcript;
+                }
+            }
+            transcribedText.textContent = final_transcript || interim_transcript;
+        };
+
+        recognition.onend = () => {
+            logButton.textContent = 'Log';
+            logButton.disabled = false;
+            if (final_transcript) {
+                transcribedText.textContent = final_transcript;
+                confirmationArea.style.display = 'block';
+            }
+        };
+
+        recognition.onerror = (event) => {
+            console.error('Speech recognition error', event.error);
+            logButton.textContent = 'Log';
+            logButton.disabled = false;
+        };
+    } else {
+        alert('Your browser does not support the Web Speech API. Please try Chrome or another supported browser.');
+        logButton.disabled = true;
+    }
+
+    logButton.addEventListener('click', () => {
+        if (recognition) {
+            final_transcript = '';
+            recognition.start();
+        }
+    });
+
+    confirmButton.addEventListener('click', () => {
+        const message = final_transcript;
+        if (message) {
+            const timestamp = new Date().toISOString();
+            const record = { message, timestamp };
+
+            let records = JSON.parse(localStorage.getItem('babyLogRecords')) || [];
+            records.push(record);
+            localStorage.setItem('babyLogRecords', JSON.stringify(records));
+
+            confirmationArea.style.display = 'none';
+            final_transcript = '';
+            transcribedText.textContent = '';
+            alert('Record saved!');
+        }
+    });
+
+    tryAgainButton.addEventListener('click', () => {
+        confirmationArea.style.display = 'none';
+        final_transcript = '';
+        transcribedText.textContent = '';
+    });
+
+    function displayRecords(records) {
+        recordsContainer.innerHTML = ''; // Clear previous records
+        if (!records || records.length === 0) {
+            recordsContainer.innerHTML = '<p>No records found.</p>';
+            return;
+        }
+
+        // Sort records by timestamp, newest first
+        records.sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
+
+        records.forEach(record => {
+            const recordElement = document.createElement('div');
+            recordElement.classList.add('record');
+
+            const messageElement = document.createElement('p');
+            messageElement.textContent = record.message;
+
+            const timeElement = document.createElement('small');
+            timeElement.textContent = new Date(record.timestamp).toLocaleString();
+
+            recordElement.appendChild(messageElement);
+            recordElement.appendChild(timeElement);
+
+            recordsContainer.appendChild(recordElement);
+        });
+    }
+
+    function loadAndDisplayRecords() {
+        const records = JSON.parse(localStorage.getItem('babyLogRecords')) || [];
+        displayRecords(records);
+    }
+
+    showRecordsButton.addEventListener('click', () => {
+        const isDisplayed = recordsArea.style.display !== 'none';
+        recordsArea.style.display = isDisplayed ? 'none' : 'block';
+        if (!isDisplayed) {
+            loadAndDisplayRecords();
+        }
+    });
+
+    filterButton.addEventListener('click', () => {
+        const startDate = startDateInput.value ? new Date(startDateInput.value) : null;
+        const endDate = endDateInput.value ? new Date(endDateInput.value) : null;
+
+        const allRecords = JSON.parse(localStorage.getItem('babyLogRecords')) || [];
+
+        const filteredRecords = allRecords.filter(record => {
+            const recordDate = new Date(record.timestamp);
+            if (startDate && recordDate < startDate) {
+                return false;
+            }
+            if (endDate && recordDate > endDate) {
+                return false;
+            }
+            return true;
+        });
+
+        displayRecords(filteredRecords);
+    });
+});


### PR DESCRIPTION
This commit introduces a new webpage, `babylog.html`, which allows users to log events using their voice.

Key features include:
- A "Log" button that uses the Web Speech API to transcribe the user's voice to text.
- A confirmation step to ensure the transcribed message is accurate before saving.
- Messages are saved with a timestamp to the browser's local storage.
- A "Show Records" button to display all saved logs.
- Time-based filters to view logs from a specific date and time range.

The implementation is self-contained in `babylog.html`, `babylog.css`, and `babylog.js`.