### PR TITLE
feat: Enhance Baby Log with standard logs and time parsing

### DIFF
--- a/babylog.css
+++ b/babylog.css
@@ -37,3 +37,43 @@ button {
 .record:last-child {
     border-bottom: none;
 }
+
+.controls {
+    margin-bottom: 20px;
+}
+
+#standard-log-area {
+    margin-top: 20px;
+    padding: 20px;
+    border: 1px solid #ccc;
+    border-radius: 5px;
+}
+
+.form-group {
+    margin-bottom: 15px;
+}
+
+.form-group label {
+    display: block;
+    margin-bottom: 5px;
+}
+
+.form-group select, .form-group input {
+    width: 100%;
+    padding: 8px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+}
+
+#success-message {
+    position: fixed;
+    bottom: 20px;
+    left: 50%;
+    transform: translateX(-50%);
+    background-color: #4CAF50;
+    color: white;
+    padding: 15px;
+    border-radius: 5px;
+    z-index: 1000;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+}

--- a/babylog.html
+++ b/babylog.html
@@ -9,8 +9,40 @@
 <body>
     <h1>Baby Log</h1>
 
-    <button id="log-button">Log</button>
-    <button id="show-records-button">Show Records</button>
+    <div class="controls">
+        <button id="log-button">Voice Log</button>
+        <button id="show-records-button">Show Records</button>
+    </div>
+
+    <div id="standard-log-area">
+        <h2>Standard Log</h2>
+        <form id="standard-log-form">
+            <div class="form-group">
+                <label for="event-type">Event:</label>
+                <select id="event-type" name="event-type">
+                    <option value="feed">Feed</option>
+                    <option value="poo">Poo</option>
+                    <option value="urine">Urine</option>
+                </select>
+            </div>
+            <div class="form-group">
+                <label for="time-offset">Time:</label>
+                <select id="time-offset" name="time-offset">
+                    <option value="0">Now</option>
+                    <option value="15">15 minutes ago</option>
+                    <option value="30">30 minutes ago</option>
+                    <option value="60">1 hour ago</option>
+                    <option value="120">2 hours ago</option>
+                    <option value="custom">Custom</option>
+                </select>
+            </div>
+            <div class="form-group" id="custom-time-group" style="display: none;">
+                <label for="custom-time">Custom Time:</label>
+                <input type="datetime-local" id="custom-time" name="custom-time">
+            </div>
+            <button type="submit" id="save-log-button">Save Log</button>
+        </form>
+    </div>
 
     <div id="confirmation-area" style="display: none;">
         <p id="transcribed-text"></p>
@@ -29,6 +61,8 @@
         </div>
         <div id="records-container"></div>
     </div>
+
+    <div id="success-message" style="display: none;"></div>
 
     <script src="babylog.js"></script>
 </body>


### PR DESCRIPTION
This commit introduces several enhancements to the Baby Log webpage based on user feedback.

Key updates include:
- **Standard Log Form**: A new form has been added to allow users to quickly log common events (Feed, Poo, Urine) with predefined or custom timestamps.
- **Voice Log Time Parsing**: The voice log functionality is now smarter. It can parse relative time expressions from the user's speech (e.g., "30 minutes ago", "yesterday") and save the log with the correct timestamp. It falls back to the current time if no time is mentioned.
- **Improved UX**: The "Log" button is renamed to "Voice Log" for clarity. The `alert()` pop-up on save has been replaced with a non-blocking success message that appears temporarily at the bottom of the screen.

These changes make the logging process more flexible and user-friendly.