### PR TITLE
feat: Replace dropdowns with quick-select radio buttons

### DIFF
--- a/babylog.css
+++ b/babylog.css
@@ -11,14 +11,37 @@ button {
     padding: 10px 20px;
     font-size: 16px;
     cursor: pointer;
-    margin: 10px;
+    margin: 0 5px;
 }
 
-#confirmation-area, #records-area {
-    margin-top: 20px;
+.controls {
+    text-align: center;
+    margin-bottom: 20px;
+}
+
+#standard-log-area, #confirmation-area, #records-area {
+    margin: 20px auto;
     padding: 20px;
     border: 1px solid #ccc;
     border-radius: 5px;
+    max-width: 500px;
+}
+
+.form-group {
+    margin-bottom: 15px;
+}
+
+.form-group label {
+    display: block;
+    margin-bottom: 5px;
+}
+
+.form-group select, .form-group input {
+    width: 100%;
+    padding: 8px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    box-sizing: border-box;
 }
 
 #filters {
@@ -38,31 +61,28 @@ button {
     border-bottom: none;
 }
 
-.controls {
-    margin-bottom: 20px;
+.radio-group {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
 }
 
-#standard-log-area {
-    margin-top: 20px;
-    padding: 20px;
+.radio-group input[type="radio"] {
+    display: none; /* Hide the actual radio button */
+}
+
+.radio-group label {
+    padding: 8px 16px;
     border: 1px solid #ccc;
-    border-radius: 5px;
+    border-radius: 16px;
+    cursor: pointer;
+    transition: all 0.2s ease-in-out;
 }
 
-.form-group {
-    margin-bottom: 15px;
-}
-
-.form-group label {
-    display: block;
-    margin-bottom: 5px;
-}
-
-.form-group select, .form-group input {
-    width: 100%;
-    padding: 8px;
-    border: 1px solid #ccc;
-    border-radius: 4px;
+.radio-group input[type="radio"]:checked + label {
+    background-color: #007bff;
+    color: white;
+    border-color: #007bff;
 }
 
 #success-message {

--- a/babylog.html
+++ b/babylog.html
@@ -10,7 +10,7 @@
     <h1>Baby Log</h1>
 
     <div class="controls">
-        <button id="log-button">Voice Log</button>
+        <button id="voice-log-button">Voice Log</button>
         <button id="show-records-button">Show Records</button>
     </div>
 
@@ -18,23 +18,23 @@
         <h2>Standard Log</h2>
         <form id="standard-log-form">
             <div class="form-group">
-                <label for="event-type">Event:</label>
-                <select id="event-type" name="event-type">
-                    <option value="feed">Feed</option>
-                    <option value="poo">Poo</option>
-                    <option value="urine">Urine</option>
-                </select>
+                <label>Event:</label>
+                <div class="radio-group" id="event-type-group">
+                    <input type="radio" id="event-feed" name="event-type" value="Feed" checked><label for="event-feed">Feed</label>
+                    <input type="radio" id="event-poo" name="event-type" value="Poo"><label for="event-poo">Poo</label>
+                    <input type="radio" id="event-urine" name="event-type" value="Urine"><label for="event-urine">Urine</label>
+                </div>
             </div>
             <div class="form-group">
-                <label for="time-offset">Time:</label>
-                <select id="time-offset" name="time-offset">
-                    <option value="0">Now</option>
-                    <option value="15">15 minutes ago</option>
-                    <option value="30">30 minutes ago</option>
-                    <option value="60">1 hour ago</option>
-                    <option value="120">2 hours ago</option>
-                    <option value="custom">Custom</option>
-                </select>
+                <label>Time:</label>
+                <div class="radio-group" id="time-offset-group">
+                    <input type="radio" id="time-0" name="time-offset" value="0" checked><label for="time-0">Now</label>
+                    <input type="radio" id="time-15" name="time-offset" value="15"><label for="time-15">15m ago</label>
+                    <input type="radio" id="time-30" name="time-offset" value="30"><label for="time-30">30m ago</label>
+                    <input type="radio" id="time-60" name="time-offset" value="60"><label for="time-60">1h ago</label>
+                    <input type="radio" id="time-120" name="time-offset" value="120"><label for="time-120">2h ago</label>
+                    <input type="radio" id="time-custom" name="time-offset" value="custom"><label for="time-custom">Custom</label>
+                </div>
             </div>
             <div class="form-group" id="custom-time-group" style="display: none;">
                 <label for="custom-time">Custom Time:</label>


### PR DESCRIPTION
This commit refactors the standard log form to improve user experience by replacing the <select> dropdowns for "Event" and "Time" with a more direct, chip-style quick-select interface.

This change makes all logging options visible at once, allowing for faster and easier data entry.

The new UI is implemented using standard HTML radio buttons, which are then styled with CSS to hide the default input and make the labels look like selectable chips. The JavaScript has been updated to get the selected values from the new radio button groups.