### PR TITLE
fix: Add 'urinated' to report keywords

### DIFF
--- a/babylog.js
+++ b/babylog.js
@@ -85,7 +85,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const keywords = {
             Feed: ['feed', 'food', 'eat', 'ate', 'nurse', 'nursing', 'bottle', 'fed'],
             Poo: ['poo', 'poop', 'pooped', 'soiled', 'bowel movement'],
-            Urine: ['urine', 'urinate', 'pee', 'wet']
+            Urine: ['urine', 'urinate', 'urinated', 'pee', 'wet']
         };
 
         function getEventType(message) {


### PR DESCRIPTION
This commit adds the word "urinated" to the list of keywords for "Urine" events in the report generation logic. This improves the accuracy of the reporting feature.