### PR TITLE
Add enhanced summary to log page and report

### DIFF
--- a/babylog.html
+++ b/babylog.html
@@ -19,6 +19,7 @@
         <div class="tab-content">
             <!-- Log Tab -->
             <div id="log-tab" class="tab-panel active">
+                <div id="log-summary-container" class="summary-container"></div>
                 <div class="log-controls">
                     <button id="voice-log-button">Log with Voice</button>
                 </div>
@@ -75,7 +76,7 @@
                 <h2>Reports</h2>
                 <div id="report-summary">
                     <h3>Last 24 Hours</h3>
-                    <div id="summary-container">
+                    <div id="summary-container" class="summary-container">
                         <!-- Summary stats will be injected here -->
                     </div>
                 </div>


### PR DESCRIPTION
- The summary is now displayed on both the 'Log' and 'Report' tabs.
- The summary now includes the time elapsed since the last 'Feed', 'Poo', and 'Urine' event.
- Refactored the summary generation logic for better reusability.