### PR TITLE
Fix: Remove 'ago' from summary time values

### DIFF
--- a/babylog.css
+++ b/babylog.css
@@ -143,6 +143,31 @@ button {
     background-color: #f2f2f2;
 }
 
+.summary-details {
+    border: 1px solid #ccc;
+    border-radius: 5px;
+    padding: 10px 15px;
+    margin-bottom: 20px;
+}
+
+.summary-details summary {
+    font-weight: bold;
+    cursor: pointer;
+    padding: 5px 0;
+}
+
+.summary-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 10px;
+}
+
+.summary-table th, .summary-table td {
+    border: 1px solid #ddd;
+    padding: 8px;
+    text-align: left;
+}
+
 #success-message {
     position: fixed;
     bottom: 20px;

--- a/babylog.js
+++ b/babylog.js
@@ -101,16 +101,16 @@ document.addEventListener('DOMContentLoaded', () => {
         if (!date) return 'N/A';
         const seconds = Math.floor((new Date() - date) / 1000);
         let interval = seconds / 31536000;
-        if (interval > 1) return Math.floor(interval) + " years ago";
+        if (interval > 1) return Math.floor(interval) + " years";
         interval = seconds / 2592000;
-        if (interval > 1) return Math.floor(interval) + " months ago";
+        if (interval > 1) return Math.floor(interval) + " months";
         interval = seconds / 86400;
-        if (interval > 1) return Math.floor(interval) + " days ago";
+        if (interval > 1) return Math.floor(interval) + " days";
         interval = seconds / 3600;
-        if (interval > 1) return Math.floor(interval) + "h " + Math.floor((seconds % 3600) / 60) + "m ago";
+        if (interval > 1) return Math.floor(interval) + "h " + Math.floor((seconds % 3600) / 60) + "m";
         interval = seconds / 60;
-        if (interval > 1) return Math.floor(interval) + "m ago";
-        return Math.floor(seconds) + "s ago";
+        if (interval > 1) return Math.floor(interval) + "m";
+        return Math.floor(seconds) + "s";
     }
 
     function updateSummary(allRecords) {
@@ -159,7 +159,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         <td>${summaryCounts.Urine}</td>
                     </tr>
                     <tr>
-                        <td><strong>Last Event</strong></td>
+                        <td><strong>Last Event (ago)</strong></td>
                         <td>${formatTimeSince(lastEvents.Feed)}</td>
                         <td>${formatTimeSince(lastEvents.Poo)}</td>
                         <td>${formatTimeSince(lastEvents.Urine)}</td>


### PR DESCRIPTION
- Updates the `formatTimeSince` function to no longer append ' ago' to the end of the time string.
- Updates the 'Last Event' row header in the summary table to 'Last Event (ago)' to provide context.